### PR TITLE
Fix certain fines causing ETS2 Telemetry Server to crash until game restart

### DIFF
--- a/source/Funbit.Ets.Telemetry.Server/Data/Ets2TelemetryData.cs
+++ b/source/Funbit.Ets.Telemetry.Server/Data/Ets2TelemetryData.cs
@@ -31,7 +31,9 @@ namespace Funbit.Ets.Telemetry.Server.Data
         {
             if (bytes == null)
                 return string.Empty;
-            return Encoding.UTF8.GetString(bytes, 0, Array.FindIndex(bytes, b => b == 0));
+            var length = Array.FindIndex(bytes, b => b == 0);
+            if (length == -1) length = bytes.Length;
+            return Encoding.UTF8.GetString(bytes, 0, length);
         }
 
         public IEts2Game Game => new Ets2Game(_rawData);


### PR DESCRIPTION
In a recent-ish version, some new fines were added. When these trigger, the current event causes ETS2 Telemetry Server to crash:

```json
{
  "message": "An error has occurred.",
  "exceptionMessage": "Error getting value from 'FineOffense' on 'Funbit.Ets.Telemetry.Server.Data.Ets2FinedGameplayEvent'.",
  "exceptionType": "Newtonsoft.Json.JsonSerializationException",
  "stackTrace": "   bij Newtonsoft.Json.Serialization.DynamicValueProvider.GetValue(Object target)\r\n   bij Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.CalculatePropertyValues(JsonWriter writer, Object value, JsonContainerContract contract, JsonProperty member, JsonProperty property, JsonContract& memberContract, Object& memberValue)\r\n   bij Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeObject(JsonWriter writer, Object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)\r\n   bij Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeValue(JsonWriter writer, Object value, JsonContract valueContract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty)\r\n   bij Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeObject(JsonWriter writer, Object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)\r\n   bij Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeValue(JsonWriter writer, Object value, JsonContract valueContract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty)\r\n   bij Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.Serialize(JsonWriter jsonWriter, Object value, Type objectType)\r\n   bij Newtonsoft.Json.JsonSerializer.SerializeInternal(JsonWriter jsonWriter, Object value, Type objectType)\r\n   bij Newtonsoft.Json.JsonConvert.SerializeObjectInternal(Object value, Type type, JsonSerializer jsonSerializer)\r\n   bij Funbit.Ets.Telemetry.Server.Controllers.Ets2TelemetryController.GetEts2TelemetryJson()\r\n   bij Funbit.Ets.Telemetry.Server.Controllers.Ets2TelemetryController.Get()\r\n   bij lambda_method(Closure , Object , Object[] )\r\n   bij System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ActionExecutor.<>c__DisplayClass10.<GetExecutor>b__9(Object instance, Object[] methodParameters)\r\n   bij System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ActionExecutor.Execute(Object instance, Object[] arguments)\r\n   bij System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ExecuteAsync(HttpControllerContext controllerContext, IDictionary`2 arguments, CancellationToken cancellationToken)\r\n--- Einde van stacktracering vanaf vorige locatie waar uitzondering is opgetreden ---\r\n   bij System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   bij System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   bij System.Web.Http.Controllers.ApiControllerActionInvoker.<InvokeActionAsyncCore>d__0.MoveNext()\r\n--- Einde van stacktracering vanaf vorige locatie waar uitzondering is opgetreden ---\r\n   bij System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   bij System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   bij System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__2.MoveNext()\r\n--- Einde van stacktracering vanaf vorige locatie waar uitzondering is opgetreden ---\r\n   bij System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   bij System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   bij System.Web.Http.Dispatcher.HttpControllerDispatcher.<SendAsync>d__1.MoveNext()",
  "innerException": {
    "message": "An error has occurred.",
    "exceptionMessage": "Niet-negatief getal is vereist.\r\nParameternaam: count",
    "exceptionType": "System.ArgumentOutOfRangeException",
    "stackTrace": "   bij System.Text.UTF8Encoding.GetString(Byte[] bytes, Int32 index, Int32 count)\r\n   bij Funbit.Ets.Telemetry.Server.Data.Ets2TelemetryData.BytesToString(Byte[] bytes)\r\n   bij GetFineOffense(Object )\r\n   bij Newtonsoft.Json.Serialization.DynamicValueProvider.GetValue(Object target)"
  }
}
```

The offence here is "Damaged_Vehicle_Usage".

This fixes that in the sense that it no longer crashes.